### PR TITLE
Mark consumer groups as not supported in tests

### DIFF
--- a/pkg/firestore/pubsub_test.go
+++ b/pkg/firestore/pubsub_test.go
@@ -50,7 +50,7 @@ func TestPublishSubscribe(t *testing.T) {
 	tests.TestPubSub(
 		t,
 		tests.Features{
-			ConsumerGroups:      true,
+			ConsumerGroups:      false,
 			ExactlyOnceDelivery: false,
 			GuaranteedOrder:     false,
 			Persistent:          true,


### PR DESCRIPTION
I am under the impression that consumer groups are not actually supported. I believe that the statement "consumer groups are supported" actually means something along the lines of "multiple subscribers listening to the same subscription will not be fighting over messages and a message will be delivered to only one of them". This statement seems to be false.