### PR TITLE
subscription: Periodically read all messages from subscription collection

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,5 +8,5 @@ services:
     env_file:
       - "./.env"
     ports:
-      - 8080:8080
+      - "8080:8787"
     restart: unless-stopped

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa // indirect
 	google.golang.org/api v0.9.0
 	google.golang.org/grpc v1.21.1

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/firestore/subscriber.go
+++ b/pkg/firestore/subscriber.go
@@ -17,7 +17,7 @@ import (
 const (
 	defaultPubSubRootCollection = "pubsub"
 	defaultTimeout              = time.Second * 30
-	defaultReadAllPeriod        = time.Second * 30
+	defaultReadAllPeriod        = time.Second * 10
 
 	subscriptionsCollection = "subscriptions"
 )

--- a/pkg/firestore/subscription.go
+++ b/pkg/firestore/subscription.go
@@ -2,8 +2,10 @@ package firestore
 
 import (
 	"context"
+	"time"
 
 	"cloud.google.com/go/firestore"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -24,7 +26,13 @@ type subscription struct {
 	output  chan *message.Message
 }
 
-func newSubscription(name, topic string, config SubscriberConfig, client client, logger watermill.LoggerAdapter, closing chan struct{}) (*subscription, error) {
+func newSubscription(
+	name, topic string,
+	config SubscriberConfig,
+	client client,
+	logger watermill.LoggerAdapter,
+	closing chan struct{},
+) (*subscription, error) {
 	s := &subscription{
 		name:    name,
 		topic:   topic,
@@ -43,37 +51,64 @@ func newSubscription(name, topic string, config SubscriberConfig, client client,
 }
 
 func (s *subscription) receive(ctx context.Context) {
-	s.readAll(ctx)
-	s.watchChanges(ctx)
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		return s.watchChanges(ctx)
+	})
+
+	g.Go(func() error {
+		return s.readAllPeriodically(ctx)
+	})
+
+	if err := g.Wait(); err != nil {
+		s.logger.Error("Subscription receive failure", err, nil)
+	}
 }
 
-func (s *subscription) readAll(ctx context.Context) {
-	s.logger.Debug("Reading messages on receive start", nil)
+func (s *subscription) readAllPeriodically(ctx context.Context) error {
+	ticker := time.NewTicker(s.config.ReadAllPeriod)
+
+	for {
+		select {
+		case <-ticker.C:
+			s.logger.Debug("Reading all messages", nil)
+			if err := s.readAll(ctx); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (s *subscription) readAll(ctx context.Context) error {
 	docs, err := s.messagesQuery().Documents(ctx).GetAll()
 	if err != nil {
 		s.logger.Error("Couldn't read messages on receive start", err, nil)
+		return err
 	}
 	for _, doc := range docs {
 		s.handleAddedMessage(ctx, doc)
 	}
 
-	s.logger.Trace("Reading messages from sub", nil)
+	return nil
 }
 
-func (s *subscription) watchChanges(ctx context.Context) {
+func (s *subscription) watchChanges(ctx context.Context) error {
 	subscriptionSnapshots := s.messagesQuery().Query.Snapshots(ctx)
 	defer subscriptionSnapshots.Stop()
 	for {
 		subscriptionSnapshot, err := subscriptionSnapshots.Next()
 		if err == iterator.Done {
 			s.logger.Debug("Listening on subscription done", nil)
-			break
+			return err
 		} else if status.Code(err) == codes.Canceled {
 			s.logger.Debug("Receive context canceled", nil)
-			break
+			return err
 		} else if err != nil {
 			s.logger.Error("Error receiving", err, nil)
-			break
+			return err
 		}
 
 		if subscriptionSnapshot.Size == 0 {
@@ -140,7 +175,11 @@ func (s *subscription) handleAddedMessage(ctx context.Context, doc *firestore.Do
 	}
 }
 
-func (s *subscription) ackMessage(ctx context.Context, message *firestore.DocumentSnapshot, logger watermill.LoggerAdapter) error {
+func (s *subscription) ackMessage(
+	ctx context.Context,
+	message *firestore.DocumentSnapshot,
+	logger watermill.LoggerAdapter,
+) error {
 	deleteCtx, deleteCancel := context.WithTimeout(ctx, s.config.Timeout)
 	defer deleteCancel()
 	_, err := message.Ref.Delete(deleteCtx, firestore.Exists)


### PR DESCRIPTION
We've got a production service that has a long running Firestore subscription. It appears that sometimes it skips a message (Firestore 'watch changes' bug?) which results in messages being never consumed, but only after a service restart. This PR solves the issue by introducing periodic polling of messages additionally to the regular changes watching. 